### PR TITLE
Refactor the workshop signup flow to better handle error cases

### DIFF
--- a/app/controllers/work_signups_controller.rb
+++ b/app/controllers/work_signups_controller.rb
@@ -1,35 +1,54 @@
 class WorkSignupsController < ApplicationController
   before_filter :authenticate_user!, except: [:index]
+  before_filter :fetch_workshop
 
   def new
-  	@workshop = Workshop.find(params[:workshop_id])
   	@work_signup = WorkSignup.new
   end
 
   def create
-	  @workshop = Workshop.find(params[:workshop_id])
     @work_signup = WorkSignup.new(params[:work_signup])
     @work_signup.event_id = @workshop.id
     @work_signup.user_id = current_user.id
   	current_user.update_attributes(params[:user])
 
-    @workshop
     if @work_signup.save
-      if @work_signup.process_workshop_fee
-        if @work_signup.signup
-          redirect_to workshops_path, :flash => { :success => "Awesome, you're all signed up to work with #{@workshop.host_firstname}." }
-        else
-          flash.now[:warning] = "Welp, that submit didn't work."
-          render 'new'
-        end
-      else
-        flash.now[:warning] = "Glurphhh, that save didn't work."
-        render 'new'
-      end
+      process_signup
     else
-      flash.now[:notify] = "There was an error signing up."
+      flash.now[:notify] = 'There was an error signing up.'
       render 'new'
     end
   end
 
+  def update
+    @work_signup = WorkSignup.find(params[:id])
+    current_user.update_attributes(params[:user])
+
+    if @work_signup.update_attributes(params[:work_signup])
+      process_signup
+    else
+      flash.now[:notify] = 'There was an error signing up.'
+      render 'new'
+    end
+  end
+
+  private
+
+  def process_signup
+    begin
+      @work_signup.process_signup!
+
+      redirect_to workshops_path, :flash => { :success => "Awesome, you're all signed up to work with #{@workshop.host_firstname}." }
+    rescue PaymentError
+      flash.now[:warning] = 'There was an error processing your payment.'
+      render 'new'
+    rescue SignupError
+      flash.now[:warning] = 'There was an error signing up for this workshop.'
+      render 'new'
+    end
+  end
+
+  def fetch_workshop
+    @workshop = Workshop.find(params[:workshop_id])
+  end
 end

--- a/app/models/work_signup.rb
+++ b/app/models/work_signup.rb
@@ -1,8 +1,20 @@
+class PaymentError < StandardError; end
+class SignupError < StandardError; end
+
 class WorkSignup < Signup
 
   validates :waiver, :acceptance => true
 
   include Emailable
+
+  # Creates a sign up object, processes payment, and marks sign up
+  # process as completed on the sign up object.
+  #
+  # Returns true if sign up completed successfully, raises exception otherwise.
+  def process_signup!
+    raise PaymentError unless process_workshop_fee
+    raise SignupError  unless signup
+  end
 
   def process_workshop_fee
     logger.info "Processing payment"


### PR DESCRIPTION
There was a bug that could be triggered whereby a user could cause an error in payment after the `WorkSignup` model had already been created, which would cause the form rerendered in the new action to point at the `update` action for that model. Since the controller had no `update` action, any subsequent attempts to correct the issues and sign up would fail.

I created an `update` action and pushed down more of the signup logic into the model, which signals the controller by raising errors.
